### PR TITLE
Add button to view dashboard after successful pipeline run / completion

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)",
+      "Bash(grep:*)",
+      "Bash(npm run compile:*)"
+    ],
+    "deny": []
+  }
+}

--- a/assets/main.css
+++ b/assets/main.css
@@ -448,11 +448,107 @@ footer .run-pipeline-button.running {
 footer .run-pipeline-button.completed {
   background: var(--zenml-green);
   color: white;
+  cursor: default;
+}
+
+footer .run-pipeline-button.completed:hover {
+  background: var(--zenml-green);
+  transform: none;
+  box-shadow: none;
 }
 
 footer .run-pipeline-button.failed {
   background: var(--zenml-red);
   color: white;
+}
+
+/* Dashboard button styling */
+.dashboard-button {
+  background: var(--zenml-purple);
+  border: none;
+  color: #ffffff;
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 140px;
+  justify-content: center;
+  font-family: "Inter", sans-serif;
+  margin: 0;
+  height: 40px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.dashboard-button:hover {
+  background: var(--zenml-purple-dark);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(122, 62, 244, 0.3);
+  color: white;
+  text-decoration: none;
+}
+
+.dashboard-button:active {
+  transform: translateY(0);
+}
+
+.dashboard-button:visited {
+  color: white;
+}
+
+.dashboard-button .codicon {
+  font-size: 16px;
+}
+
+/* Pipeline button group */
+.pipeline-button-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Dashboard button styling - smaller variant */
+.dashboard-button-small {
+  background: var(--vscode-button-secondaryBackground);
+  border: 1px solid var(--vscode-sideBar-border);
+  color: var(--vscode-button-secondaryForeground);
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: center;
+  font-family: "Inter", sans-serif;
+  margin: 0;
+  height: 36px;
+  text-decoration: none;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.dashboard-button-small:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  color: var(--vscode-button-secondaryForeground);
+  text-decoration: none;
+}
+
+.dashboard-button-small:active {
+  transform: translateY(0);
+}
+
+.dashboard-button-small .codicon {
+  font-size: 14px;
 }
 
 #progress {

--- a/assets/main.css
+++ b/assets/main.css
@@ -517,9 +517,9 @@ footer .run-pipeline-button.failed {
   background: var(--vscode-button-secondaryBackground);
   border: 1px solid var(--vscode-sideBar-border);
   color: var(--vscode-button-secondaryForeground);
-  padding: 8px 16px;
+  padding: 10px 16px;
   border-radius: 6px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -529,7 +529,7 @@ footer .run-pipeline-button.failed {
   justify-content: center;
   font-family: "Inter", sans-serif;
   margin: 0;
-  height: 36px;
+  height: 40px;
   text-decoration: none;
   flex-shrink: 0;
   white-space: nowrap;

--- a/assets/main.css
+++ b/assets/main.css
@@ -462,48 +462,6 @@ footer .run-pipeline-button.failed {
   color: white;
 }
 
-/* Dashboard button styling */
-.dashboard-button {
-  background: var(--zenml-purple);
-  border: none;
-  color: #ffffff;
-  padding: 10px 20px;
-  border-radius: 6px;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 140px;
-  justify-content: center;
-  font-family: "Inter", sans-serif;
-  margin: 0;
-  height: 40px;
-  text-decoration: none;
-  flex-shrink: 0;
-}
-
-.dashboard-button:hover {
-  background: var(--zenml-purple-dark);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(122, 62, 244, 0.3);
-  color: white;
-  text-decoration: none;
-}
-
-.dashboard-button:active {
-  transform: translateY(0);
-}
-
-.dashboard-button:visited {
-  color: white;
-}
-
-.dashboard-button .codicon {
-  font-size: 16px;
-}
 
 /* Pipeline button group */
 .pipeline-button-group {

--- a/assets/main.css
+++ b/assets/main.css
@@ -517,10 +517,10 @@ footer .run-pipeline-button.failed {
   background: var(--vscode-button-secondaryBackground);
   border: 1px solid var(--vscode-sideBar-border);
   color: var(--vscode-button-secondaryForeground);
-  padding: 10px 16px;
+  padding: 9px 16px;
   border-radius: 6px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.3s ease;
   display: flex;
@@ -529,10 +529,11 @@ footer .run-pipeline-button.failed {
   justify-content: center;
   font-family: "Inter", sans-serif;
   margin: 0;
-  height: 40px;
+  height: 38px;
   text-decoration: none;
   flex-shrink: 0;
   white-space: nowrap;
+  box-sizing: border-box;
 }
 
 .dashboard-button-small:hover {

--- a/assets/main.js
+++ b/assets/main.js
@@ -502,10 +502,10 @@
       dashboardButton.style.display = "flex";
       
       // Add click handler to open in external browser
-      dashboardButton.onclick = function(e) {
+      dashboardButton.addEventListener('click', function(e) {
         e.preventDefault();
         vscode.postMessage({ type: "openDashboard", url: url });
-      };
+      });
     }
   }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -476,7 +476,8 @@
       } else if (status === "completed" || status === "cached") {
         runButton.innerHTML = `<i class="checkmark">✓</i> ${buttonTexts[status]}`;
         //@ts-ignore
-        runButton.disabled = false;
+        runButton.disabled = true;
+        runButton.style.cursor = "default";
       } else if (status === "failed") {
         runButton.innerHTML = `<i class="codicon codicon-error"></i> ${buttonTexts[status]}`;
         //@ts-ignore
@@ -493,14 +494,18 @@
   }
 
   function showDashboardUrl(url) {
-    const dashboardLink = document.getElementById("dashboard-link");
-    const dashboardUrl = document.getElementById("dashboard-url");
+    const dashboardButton = document.getElementById("dashboard-button");
 
-    if (dashboardLink && dashboardUrl) {
+    if (dashboardButton) {
       //@ts-ignore
-      dashboardUrl.href = url;
-      dashboardUrl.textContent = "View Pipeline in Dashboard";
-      dashboardLink.style.display = "flex";
+      dashboardButton.href = url;
+      dashboardButton.style.display = "flex";
+      
+      // Add click handler to open in external browser
+      dashboardButton.onclick = function(e) {
+        e.preventDefault();
+        vscode.postMessage({ type: "openDashboard", url: url });
+      };
     }
   }
 

--- a/src/tutorialOrchestrator.ts
+++ b/src/tutorialOrchestrator.ts
@@ -32,8 +32,7 @@ export default class TutorialOrchestrator {
     if (runId) {
       return `${baseUrl}/workspaces/default/runs/${runId}`;
     } else {
-      // Get the current pipeline name from the tutorial section
-      const pipelineName = this._tutorial.currentSection.code()?.split('/').pop()?.replace('.py', '') || 'pipelines';
+      // Fallback to generic pipelines page when no specific run ID
       return `${baseUrl}/workspaces/default/pipelines`;
     }
   }

--- a/src/tutorialOrchestrator.ts
+++ b/src/tutorialOrchestrator.ts
@@ -27,8 +27,15 @@ export default class TutorialOrchestrator {
   private _getDashboardUrl(runId?: string): string {
     const baseUrl = vscode.workspace
       .getConfiguration("zenml")
-      .get<string>("dashboardUrl", "http://localhost:8080");
-    return runId ? `${baseUrl}/workspaces/default/runs/${runId}` : baseUrl;
+      .get<string>("dashboardUrl", "https://cloud.zenml.io");
+    // If we have a run ID, show specific run, otherwise show pipelines page
+    if (runId) {
+      return `${baseUrl}/workspaces/default/runs/${runId}`;
+    } else {
+      // Get the current pipeline name from the tutorial section
+      const pipelineName = this._tutorial.currentSection.code()?.split('/').pop()?.replace('.py', '') || 'pipelines';
+      return `${baseUrl}/workspaces/default/pipelines`;
+    }
   }
 
   constructor(context: vscode.ExtensionContext, tutorial: Tutorial) {
@@ -142,7 +149,7 @@ export default class TutorialOrchestrator {
       codeRunner(
         this.terminal,
         this._codePanel.document.uri,
-        () => {
+        (dashboardUrl?: string) => {
           vscode.window.showInformationMessage("Code Ran Successfully! 🎉");
           if (callback) {
             callback();
@@ -196,7 +203,7 @@ export default class TutorialOrchestrator {
       codeRunner(
         this.terminal,
         this._codePanel.document.uri,
-        (runId?: string) => {
+        (dashboardUrl?: string) => {
           // Pipeline completed successfully
           this._pipelineRunning = false;
           this._completedTutorials.add(this._tutorial.currentSection.index);
@@ -204,19 +211,17 @@ export default class TutorialOrchestrator {
             type: "pipelineStatusUpdate",
             status: "completed",
           });
-          this._sendWebviewMessage({ type: "pipelineCompleted", runId: runId });
+          this._sendWebviewMessage({ type: "pipelineCompleted" });
 
           // Save progress
           this._saveProgress();
 
-          // Show dashboard URL
-          if (runId) {
-            const dashboardUrl = this._getDashboardUrl(runId);
-            this._sendWebviewMessage({
-              type: "showDashboardUrl",
-              url: dashboardUrl,
-            });
-          }
+          // Show dashboard URL - use the captured URL or fallback to generic
+          const finalDashboardUrl = dashboardUrl || this._getDashboardUrl();
+          this._sendWebviewMessage({
+            type: "showDashboardUrl",
+            url: finalDashboardUrl,
+          });
         },
         () => {
           // Pipeline failed
@@ -779,10 +784,16 @@ export default class TutorialOrchestrator {
         <i class="codicon codicon-chevron-left"></i>
         <span>Prev</span>
       </button>
-      <button class="run-pipeline-button" id="run-pipeline">
-        <i class="codicon codicon-play"></i>
-        <span>Run Pipeline</span>
-      </button>
+      <div class="pipeline-button-group">
+        <button class="run-pipeline-button" id="run-pipeline">
+          <i class="codicon codicon-play"></i>
+          <span>Run Pipeline</span>
+        </button>
+        <a class="dashboard-button-small" id="dashboard-button" href="#" style="display: none;">
+          <i class="codicon codicon-link-external"></i>
+          <span>Open Dashboard</span>
+        </a>
+      </div>
       <button class="footer-nav-button next ${
         isLast && !isCompletionScreen ? "disabled" : ""
       }" id="nav-next" ${isLast && !isCompletionScreen ? "disabled" : ""}>

--- a/src/tutorialOrchestrator.ts
+++ b/src/tutorialOrchestrator.ts
@@ -791,7 +791,7 @@ export default class TutorialOrchestrator {
         </button>
         <a class="dashboard-button-small" id="dashboard-button" href="#" style="display: none;">
           <i class="codicon codicon-link-external"></i>
-          <span>Open Dashboard</span>
+          <span>View in dashboard</span>
         </a>
       </div>
       <button class="footer-nav-button next ${

--- a/src/utils/codeRunner.ts
+++ b/src/utils/codeRunner.ts
@@ -1,4 +1,4 @@
-import { unlinkSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import os from "os";
 import path from "path";
 import * as vscode from "vscode";
@@ -34,6 +34,8 @@ function runCode(
   // Get the project root directory (go up from pipeline file to project root)
   const projectRoot = path.resolve(path.dirname(filePath), "../..");
 
+  const dashboardUrlFile = path.join(os.tmpdir(), `dashboard_url_${uniqueId}.txt`);
+  
   writeFileSync(
     scriptPath,
     `
@@ -42,8 +44,17 @@ function runCode(
     echo "Executing code..."
     cd "${projectRoot}"
     export PYTHONPATH="${projectRoot}:$PYTHONPATH"
-    python "${filePath}"
-    if [ $? -eq 0 ]; then
+    # Capture output to extract dashboard URL
+    python "${filePath}" 2>&1 | tee /tmp/pipeline_output_${uniqueId}.log
+    RESULT=$?
+    
+    # Extract dashboard URL if present
+    grep "DASHBOARD_URL:" /tmp/pipeline_output_${uniqueId}.log | tail -1 | cut -d':' -f2- > "${dashboardUrlFile}"
+    
+    # Clean up
+    rm -f /tmp/pipeline_output_${uniqueId}.log
+    
+    if [ $RESULT -eq 0 ]; then
       touch "${successFilePath}"
     else
       touch "${errorFilePath}"
@@ -87,8 +98,21 @@ function initializeFileWatcher(
       vscode.workspace.fs.delete(uri);
       unlinkSync(scriptPath);
       watcher.dispose();
+      
+      // Try to read dashboard URL if available
+      const dashboardUrlFile = path.join(os.tmpdir(), `dashboard_url_${uniqueId}.txt`);
+      let dashboardUrl: string | undefined;
+      try {
+        if (existsSync(dashboardUrlFile)) {
+          dashboardUrl = readFileSync(dashboardUrlFile, 'utf8').trim();
+          unlinkSync(dashboardUrlFile);
+        }
+      } catch (error) {
+        // Ignore errors reading dashboard URL
+      }
+      
       if (onSuccessCallback) {
-        onSuccessCallback();
+        onSuccessCallback(dashboardUrl);
       }
     } else if (uri.fsPath.endsWith(errorFileName)) {
       vscode.workspace.fs.delete(uri);

--- a/src/utils/codeRunner.ts
+++ b/src/utils/codeRunner.ts
@@ -35,6 +35,7 @@ function runCode(
   const projectRoot = path.resolve(path.dirname(filePath), "../..");
 
   const dashboardUrlFile = path.join(os.tmpdir(), `dashboard_url_${uniqueId}.txt`);
+  const pipelineOutputLog = path.join(os.tmpdir(), `pipeline_output_${uniqueId}.log`);
   
   writeFileSync(
     scriptPath,
@@ -45,14 +46,14 @@ function runCode(
     cd "${projectRoot}"
     export PYTHONPATH="${projectRoot}:$PYTHONPATH"
     # Capture output to extract dashboard URL
-    python "${filePath}" 2>&1 | tee /tmp/pipeline_output_${uniqueId}.log
+    python "${filePath}" 2>&1 | tee "${pipelineOutputLog}"
     RESULT=$?
     
     # Extract dashboard URL if present
-    grep "DASHBOARD_URL:" /tmp/pipeline_output_${uniqueId}.log | tail -1 | cut -d':' -f2- > "${dashboardUrlFile}"
+    grep "DASHBOARD_URL:" "${pipelineOutputLog}" | tail -1 | cut -d':' -f2- > "${dashboardUrlFile}"
     
     # Clean up
-    rm -f /tmp/pipeline_output_${uniqueId}.log
+    rm -f "${pipelineOutputLog}"
     
     if [ $RESULT -eq 0 ]; then
       touch "${successFilePath}"

--- a/src/utils/codeRunner.ts
+++ b/src/utils/codeRunner.ts
@@ -7,8 +7,8 @@ import getNonce from "./getNonce";
 export default function codeRunner(
   terminal: vscode.Terminal,
   fileUri: vscode.Uri,
-  onSuccessCallback?: Function,
-  onErrorCallback?: Function
+  onSuccessCallback?: (dashboardUrl?: string) => void,
+  onErrorCallback?: () => void
 ) {
   const uniqueId = getNonce();
 
@@ -71,8 +71,8 @@ function runCode(
 function initializeFileWatcher(
   filePath: string,
   uniqueId: string,
-  onSuccessCallback?: Function,
-  onFailureCallback?: Function
+  onSuccessCallback?: (dashboardUrl?: string) => void,
+  onFailureCallback?: () => void
 ) {
   const removeLastFileFromPath = (filePath: string) => {
     let sections = filePath.split("/");

--- a/utils.py
+++ b/utils.py
@@ -25,6 +25,5 @@ def log_dashboard_urls(pipeline_name: str):
     logger.info(f"🌐 View this run: {dashboard_url}")
     logger.info(f"🌐 View all artifacts: {base_url}/artifacts")
     logger.info("=" * 60)
-    
     # Print dashboard URL for VSCode extension to capture
     print(f"DASHBOARD_URL:{dashboard_url}")

--- a/utils.py
+++ b/utils.py
@@ -25,3 +25,6 @@ def log_dashboard_urls(pipeline_name: str):
     logger.info(f"🌐 View this run: {dashboard_url}")
     logger.info(f"🌐 View all artifacts: {base_url}/artifacts")
     logger.info("=" * 60)
+    
+    # Print dashboard URL for VSCode extension to capture
+    print(f"DASHBOARD_URL:{dashboard_url}")


### PR DESCRIPTION
## Summary

  This PR improves the visibility of the ZenML dashboard after pipeline completion by implementing a split button design. Instead of just showing a "Completed ✓" status, users now see
  both the completion status AND a clear "Open Dashboard" button.

![CleanShot 2025-06-13 at 11 52 00@2x](https://github.com/user-attachments/assets/ace6c5ae-9b16-4434-904e-29a411e62101)

  ### Changes Made:

  1. **Split Button Design**
     - Replaced single button with a button group containing both "Completed" status and "Open Dashboard" link
     - Dashboard button appears only after successful pipeline completion
     - Uses secondary VSCode theme styling for visual hierarchy

  2. **Improved URL Capture**
     - Enhanced `codeRunner` to capture the actual dashboard URL from Python output
     - Dashboard button now links directly to the specific pipeline run (not just the generic pipelines page)
     - Falls back gracefully if URL capture fails

  3. **Visual Design**
     - "Completed ✓" button remains green but becomes non-interactive
     - "Open Dashboard" button is slightly smaller (36px vs 40px) with secondary styling
     - Clean 8px gap between buttons maintains visual balance
     - External link icon indicates opening in browser

  ### Before:
  `[Prev] [Completed ✓] [Next]`

  ### After:
  `[Prev] [Completed ✓] [Open Dashboard 🔗] [Next]`

  ## Motivation

  Some tutorials (like visualizations) produce interesting artifacts that users should explore in the dashboard. This change makes the dashboard more discoverable, especially for new
  users who might not notice the terminal output URLs.

  ## Test Plan

  - [x] Run a pipeline and verify the split button appears after completion
  - [x] Click "Open Dashboard" and confirm it opens the correct run-specific URL
  - [x] Verify the button styling matches VSCode theme
  - [x] Test with different pipeline types (hello_world, visualizations)
  - [x] Ensure fallback works if dashboard URL capture fails